### PR TITLE
Improve DiLiGenT-MV conversion handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ The real dataset was processed from [DiLiGenT-MV Dataset](https://sites.google.c
 The synthetic dataset was rendered using [Mitsuba](https://www.mitsuba-renderer.org/), which contains 2 objects `BUNNY`, `ARMADILLO`.
 
 After downloaded and extracted, you can find the processed datasets in `./dataset` folder.
+
+### Convert DiLiGenT-MV Data
+If you have downloaded the raw DiLiGenT-MV dataset you can reorganize an object
+into the above directory layout using `scripts/convert_diligent_mv.py`. The
+script copies the images and calibration files and generates the required
+`params.json`:
+
+```bash
+python scripts/convert_diligent_mv.py /path/to/DiLiGenT-MV/BEAR ./dataset/bear
+```
+
+The command assumes calibration files reside in a `calib/` subfolder and images
+are grouped by view in `images/view_*/`.  If the calibration file names differ
+from the defaults (`intrinsics.*`, `extrinsics.*`, `light_directions.*`), the
+script tries to locate alternatives containing the words "intrin", "extrin" and
+"light" respectively.
 ### Model
 We release the pretrained models of the 5 real scenes. After downloaded and extracted, you can find them in `./data` folder.
 
@@ -184,6 +200,18 @@ light_intensity         (optional) list of light intensity for each view as [L1*
 view_slt_N              (optional) index of selected N views for training         
 light_slt_N             (optional) index of selected N lights for training
 ```
+
+### Finding Helmholtz Pairs
+
+For DiLiGenT-MV style data you can search for nearly collocated camera-light
+pairs using `scripts/find_helmholtz_pairs.py`. The script loads `params.json`
+from an object directory and prints all view/light combinations that satisfy the
+Helmholtz condition within a specified angular threshold (default 15.5°):
+
+```bash
+python scripts/find_helmholtz_pairs.py /path/to/OBJ_NAME
+```
+
 
 
 ## Citation

--- a/scripts/convert_diligent_mv.py
+++ b/scripts/convert_diligent_mv.py
@@ -1,0 +1,135 @@
+import os
+import json
+import argparse
+from shutil import copy2
+import numpy as np
+from PIL import Image
+from scipy.io import loadmat
+
+
+def _search_file(calib_dir, keywords, exts):
+    """Return the first file in ``calib_dir`` whose name contains any of
+    ``keywords`` and ends with one of ``exts`` (case-insensitive)."""
+    for f in os.listdir(calib_dir):
+        name = f.lower()
+        if any(k in name for k in keywords) and any(name.endswith(e) for e in exts):
+            return os.path.join(calib_dir, f)
+    return None
+
+
+def _load_mat_var(path, keys):
+    data = loadmat(path)
+    for k in keys:
+        if k in data:
+            return data[k]
+    for k, v in data.items():
+        if not k.startswith("__"):
+            return v
+    raise KeyError(f"No usable variable found in {path}")
+
+
+def _load_matrix(calib_dir, def_txt, def_mat, keywords, mat_keys):
+    if def_txt:
+        p = os.path.join(calib_dir, def_txt)
+        if os.path.exists(p):
+            return np.loadtxt(p)
+    if def_mat:
+        p = os.path.join(calib_dir, def_mat)
+        if os.path.exists(p):
+            return _load_mat_var(p, mat_keys)
+
+    p = _search_file(calib_dir, keywords, ['.txt'])
+    if p is not None:
+        return np.loadtxt(p)
+    p = _search_file(calib_dir, keywords, ['.mat'])
+    if p is not None:
+        return _load_mat_var(p, mat_keys)
+    raise FileNotFoundError(f"Cannot find {keywords[0]} file")
+
+
+def load_calibration(calib_dir):
+    """Load intrinsics, extrinsics and light directions from DiLiGenT-MV calib files.
+    The function searches for common file names if the default ones are not
+    present."""
+
+    K = _load_matrix(calib_dir, 'intrinsics.txt', 'intrinsics.mat',
+                     ['intrin', 'k'], ['K'])
+    K = K.reshape(3, 3)
+
+    poses = _load_matrix(calib_dir, 'extrinsics.txt', 'extrinsics.mat',
+                         ['extrin', 'pose', 'c2w'], ['pose_c2w'])
+    poses = np.asarray(poses)
+    if poses.shape[-2:] == (4, 4):
+        poses = poses.reshape(-1, 4, 4)
+    else:
+        poses = poses.reshape(4, 4, -1).transpose(2, 0, 1)
+
+    light_dirs = _load_matrix(calib_dir, 'light_directions.txt',
+                              'light_directions.mat',
+                              ['light', 'dir'], ['light_direction'])
+    light_dirs = np.asarray(light_dirs)
+    if light_dirs.ndim == 2 and light_dirs.shape[0] == 3:
+        light_dirs = light_dirs.T
+    return K, poses, light_dirs
+
+
+def copy_images(src_dir, dst_dir):
+    view_dirs = sorted([d for d in os.listdir(src_dir) if d.lower().startswith('view')])
+    if not view_dirs:
+        raise RuntimeError('No view directories found')
+    os.makedirs(os.path.join(dst_dir, 'img'), exist_ok=True)
+    os.makedirs(os.path.join(dst_dir, 'mask'), exist_ok=True)
+
+    im_hw = None
+    for v in view_dirs:
+        src_view = os.path.join(src_dir, v)
+        dst_view = os.path.join(dst_dir, 'img', v)
+        os.makedirs(dst_view, exist_ok=True)
+        for img_name in sorted(os.listdir(src_view)):
+            if not img_name.lower().endswith(('.png', '.jpg', '.jpeg')):
+                continue
+            copy2(os.path.join(src_view, img_name), os.path.join(dst_view, img_name))
+            if im_hw is None:
+                with Image.open(os.path.join(src_view, img_name)) as img:
+                    im_hw = img.size[::-1]
+
+        mask_path = os.path.join(src_dir, 'mask', f'{v}.png')
+        if os.path.exists(mask_path):
+            copy2(mask_path, os.path.join(dst_dir, 'mask', f'{v}.png'))
+    return len(view_dirs), im_hw
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert DiLiGenT-MV data to PS-NeRF format')
+    parser.add_argument('src', type=str, help='Path to DiLiGenT-MV object directory')
+    parser.add_argument('dst', type=str, help='Destination directory')
+    parser.add_argument('--name', type=str, default=None, help='Object name')
+    args = parser.parse_args()
+
+    obj_name = args.name or os.path.basename(os.path.normpath(args.dst))
+
+    K, poses, light_dirs = load_calibration(os.path.join(args.src, 'calib'))
+    n_light = light_dirs.shape[0]
+
+    n_view, imhw = copy_images(os.path.join(args.src, 'images'), args.dst)
+
+    para = {
+        'obj_name': obj_name,
+        'n_view': int(n_view),
+        'imhw': list(map(int, imhw)),
+        'gt_normal_world': False,
+        'view_train': list(range(n_view)),
+        'view_test': [],
+        'K': K.tolist(),
+        'pose_c2w': poses.tolist(),
+        'light_is_same': True,
+        'light_direction': light_dirs.tolist(),
+    }
+
+    with open(os.path.join(args.dst, 'params.json'), 'w') as f:
+        json.dump(para, f, indent=2)
+    print('Converted object saved to', args.dst)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/find_helmholtz_pairs.py
+++ b/scripts/find_helmholtz_pairs.py
@@ -1,0 +1,76 @@
+import os
+import json
+import argparse
+import numpy as np
+
+
+def load_params(obj_dir):
+    path = os.path.join(obj_dir, 'params.json')
+    with open(path, 'r') as f:
+        para = json.load(f)
+    return para
+
+
+def normalize(v):
+    v = np.asarray(v, dtype=np.float32)
+    n = np.linalg.norm(v, axis=-1, keepdims=True)
+    n[n == 0] = 1
+    return v / n
+
+
+def get_cam_dirs(poses):
+    # camera viewing direction is the -z axis of rotation matrix
+    dirs = -np.asarray(poses, dtype=np.float32)[:, :3, 2]
+    return normalize(dirs)
+
+
+def get_light_dirs(para):
+    if para['light_is_same']:
+        dirs = np.asarray(para['light_direction'], dtype=np.float32)
+        dirs = np.broadcast_to(dirs[None, ...], (para['n_view'],) + dirs.shape)
+    else:
+        dirs = np.asarray(para['light_direction'], dtype=np.float32)
+    return normalize(dirs)
+
+
+def angle_between(a, b):
+    a = normalize(a)
+    b = normalize(b)
+    dot = np.clip((a * b).sum(-1), -1.0, 1.0)
+    return np.rad2deg(np.arccos(dot))
+
+
+def find_pairs(para, thresh=15.5):
+    poses = np.asarray(para['pose_c2w'], dtype=np.float32)
+    cam_dirs = get_cam_dirs(poses)
+    light_dirs = get_light_dirs(para)
+
+    n_view, n_light, _ = light_dirs.shape
+    pairs = []
+    for i in range(n_view):
+        for j in range(i + 1, n_view):
+            for li in range(n_light):
+                for lj in range(n_light):
+                    ang1 = angle_between(light_dirs[i, li], cam_dirs[j])
+                    ang2 = angle_between(light_dirs[j, lj], cam_dirs[i])
+                    if ang1 <= thresh and ang2 <= thresh:
+                        pairs.append(((i, li), (j, lj)))
+    return pairs
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Find Helmholtz pairs in DiLiGenT-MV style dataset')
+    parser.add_argument('obj_dir', type=str, help='Path to object directory containing params.json')
+    parser.add_argument('--thresh', type=float, default=15.5, help='Angle threshold in degrees')
+    args = parser.parse_args()
+
+    para = load_params(args.obj_dir)
+    pairs = find_pairs(para, args.thresh)
+
+    print('# Found %d Helmholtz pairs' % len(pairs))
+    for (c1, l1), (c2, l2) in pairs:
+        print('View %02d - Light %03d <-> View %02d - Light %03d' % (c1 + 1, l1 + 1, c2 + 1, l2 + 1))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- improve conversion script to search for calibration files
- document new filename detection in README

## Testing
- `python -m py_compile scripts/convert_diligent_mv.py`
- `python -m py_compile scripts/find_helmholtz_pairs.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684082ab1e148323926f8511145274e2